### PR TITLE
Refactor usage data with named fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ mod slurm;
 pub struct Usage {
     pub time: f64,
     pub cpu_load: f64,
-    pub mem_gb: f64
+    pub mem_gb: f64,
 }
 
 pub struct UsageData {
@@ -48,7 +48,7 @@ pub struct UsageData {
     pub max_time_h: f64,
     pub max_cpu_load: f64,
     pub max_memory_gb: f64,
-    pub data: HashMap<String, Vec<Usage>>
+    pub data: HashMap<String, Vec<Usage>>,
 }
 
 #[derive(Parser, Debug)]
@@ -240,7 +240,10 @@ fn ui<B: Backend>(
 
         let usage = data.get(hostname).unwrap();
 
-        let cpu_data = usage.iter().map(|Usage { time, cpu_load, .. }| (*time, *cpu_load)).collect::<Vec<_>>();
+        let cpu_data = usage
+            .iter()
+            .map(|Usage { time, cpu_load, .. }| (*time, *cpu_load))
+            .collect::<Vec<_>>();
 
         draw_chart(
             f,
@@ -254,7 +257,10 @@ fn ui<B: Backend>(
             max_cpu_load,
         );
 
-        let memory_data = usage.iter().map(|Usage { time, mem_gb, ..}| (*time, *mem_gb)).collect::<Vec<_>>();
+        let memory_data = usage
+            .iter()
+            .map(|Usage { time, mem_gb, .. }| (*time, *mem_gb))
+            .collect::<Vec<_>>();
 
         draw_chart(
             f,

--- a/src/read_data.rs
+++ b/src/read_data.rs
@@ -19,7 +19,7 @@ struct Process {
     mem_kb: u64,
 }
 
-use crate::{UsageData, Usage};
+use crate::{Usage, UsageData};
 
 // Read data from the csv files and return usage information across time broken down by hostname,
 // along with information about the data ranges.
@@ -92,7 +92,8 @@ pub fn collect_data(
             .map(|(k, (c, m))| Usage {
                 time: -((now_unix_epoch - *k) as f64) / 3600.0,
                 cpu_load: *c,
-                mem_gb: *m })
+                mem_gb: *m,
+            })
             .collect::<Vec<Usage>>();
 
         data.insert(hostname.to_string(), vec);
@@ -105,5 +106,11 @@ pub fn collect_data(
     let min_time_h = -((now_unix_epoch - min_timestamp) as f64) / 3600.0;
     let max_time_h = -((now_unix_epoch - max_timestamp) as f64) / 3600.0;
 
-    Ok(UsageData { min_time_h, max_time_h, max_cpu_load, max_memory_gb, data })
+    Ok(UsageData {
+        min_time_h,
+        max_time_h,
+        max_cpu_load,
+        max_memory_gb,
+        data,
+    })
 }


### PR DESCRIPTION
We'll be adding more data fields (minimally for gpu load) and it will soon be unworkable to use tuples.  Break out the usage data as structs with named fields instead.