### PR TITLE
replace as_ref with as_slice to make code compile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ fn ui<B: Backend>(
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(constraints_vec.as_ref())
+        .constraints(constraints_vec.as_slice())
         .split(main_chunks[1]);
 
     let mut hostnames = data.keys().collect::<Vec<_>>();


### PR DESCRIPTION
I had to change
```Rust
let chunks = Layout::default()
        .direction(Direction::Vertical)
        .constraints(constraints_vec.as_ref())
        .split(main_chunks[1]);
```
to 
```Rust
let chunks = Layout::default()
        .direction(Direction::Vertical)
        .constraints(constraints_vec.as_slice())
        .split(main_chunks[1]);
```
To make the code compile. Does this change the functionality of the code in an unintended way?
